### PR TITLE
Use Proper NYTimes API Endpoint

### DIFF
--- a/nytimes/news.go
+++ b/nytimes/news.go
@@ -50,7 +50,7 @@ type NewsResult struct {
 
 func (news *News) TopStories() (result []Result) {
 	resp, err := newsClient.R().
-		Get("http://developer.nytimes.com/proxy/https/api.nytimes.com/svc/topstories/v2/home.json?api-key=" + news.APIKey)
+		Get("https://api.nytimes.com/svc/topstories/v2/home.json?apikey=" + news.APIKey)
 	if err != nil {
 		fmt.Println(err)
 		fmt.Println(resp)


### PR DESCRIPTION
Flips the API Endpoint to use the URL instead of proxying through the developer website.